### PR TITLE
Enable reindexing service to be exposed to host of vagrant VM

### DIFF
--- a/install_scripts/fedora_camel_toolbox.sh
+++ b/install_scripts/fedora_camel_toolbox.sh
@@ -57,4 +57,5 @@ if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.reindexing.cfg" ]; then
 fi
 sed -i 's|fcrepo.authUsername=$|fcrepo.authUsername=fedoraAdmin|' /opt/karaf/etc/org.fcrepo.camel.reindexing.cfg
 sed -i 's|fcrepo.authPassword=$|fcrepo.authPassword=secret3|' /opt/karaf/etc/org.fcrepo.camel.reindexing.cfg
+sed -i 's|rest.host=localhost$|rest.host=0.0.0.0|' /opt/karaf/etc/org.fcrepo.camel.reindexing.cfg
 


### PR DESCRIPTION
See: http://camel.apache.org/jetty.html
-> Search for: "Usage of localhost"

Related to: https://jira.duraspace.org/browse/FCREPO-1980
