### PR TITLE
Omit ldp:contains triples from triplestore sync

### DIFF
--- a/install_scripts/fedora_camel_toolbox.sh
+++ b/install_scripts/fedora_camel_toolbox.sh
@@ -28,7 +28,6 @@ if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.indexing.triplestore.cfg" ]; then
 fi
 sed -i 's|fcrepo.authUsername=$|fcrepo.authUsername=fedoraAdmin|' /opt/karaf/etc/org.fcrepo.camel.indexing.triplestore.cfg
 sed -i 's|fcrepo.authPassword=$|fcrepo.authPassword=secret3|' /opt/karaf/etc/org.fcrepo.camel.indexing.triplestore.cfg
-sed -i 's|prefer.omit=http://www.w3.org/ns/ldp#PreferContainment$|prefer.omit=|' /opt/karaf/etc/org.fcrepo.camel.indexing.triplestore.cfg
 
 # Audit service
 if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.audit.cfg" ]; then


### PR DESCRIPTION
Reverts: b7d2f44d2b55b675fe9fd2f46cb12138afc3b4cd
Depends on: https://github.com/fcrepo4-exts/fcrepo4-vagrant-base-box/pull/3
Related to: https://jira.duraspace.org/browse/FCREPO-2006
