### PR TITLE
Add configuration support for AuthZ and no-AuthZ

### DIFF
--- a/install_scripts/fedora4.sh
+++ b/install_scripts/fedora4.sh
@@ -48,7 +48,7 @@ fi
 if [ "${FEDORA_AUTH}" = "true" ]; then
   MODESHAPE_CONFIG="classpath:/config/servlet-auth/repository.json"
 else
-  MODESHAPE_CONFIG="classpath:/config/minimal-default/repository.json"
+  MODESHAPE_CONFIG="classpath:/config/file-simple/repository.json"
 fi
 
 if ! grep -q "${MODESHAPE_CONFIG}" /etc/default/tomcat7 ; then


### PR DESCRIPTION
- DO NOT commit until fcrepo4-vagrant is configured for Fedora 4.7.0

Related to: https://jira.duraspace.org/browse/FCREPO-2110
