### PR TITLE
Enable karaf features to install with fcrepo-camel-toolbox:4.6.0

### DIFF
--- a/install_scripts/fedora_camel_toolbox.script
+++ b/install_scripts/fedora_camel_toolbox.script
@@ -1,6 +1,8 @@
 feature:repo-add mvn:org.fcrepo.camel/toolbox-features/4.6.0/xml/features
+feature:install fcrepo-service-activemq
+feature:install fcrepo-fixity
 feature:install fcrepo-indexing-solr
 feature:install fcrepo-indexing-triplestore
 feature:install fcrepo-reindexing
-feature:install fcrepo-fixity
 feature:install fcrepo-serialization
+feature:install fcrepo-audit-triplestore

--- a/install_scripts/fedora_camel_toolbox.sh
+++ b/install_scripts/fedora_camel_toolbox.sh
@@ -56,3 +56,4 @@ sed -i 's|rest.host=localhost$|rest.host=0.0.0.0|' /opt/karaf/etc/org.fcrepo.cam
 sed -i 's|fcrepo.authUsername=$|fcrepo.authUsername=fedoraAdmin|' /opt/karaf/etc/org.fcrepo.camel.service.cfg
 sed -i 's|fcrepo.authPassword=$|fcrepo.authPassword=secret3|' /opt/karaf/etc/org.fcrepo.camel.service.cfg
 
+/etc/init.d/karaf-service restart

--- a/install_scripts/fedora_camel_toolbox.sh
+++ b/install_scripts/fedora_camel_toolbox.sh
@@ -14,20 +14,21 @@ cd $HOME_DIR
 
 /opt/karaf/bin/client -u karaf -h localhost -a 8101 -f "$SHARED_DIR/install_scripts/fedora_camel_toolbox.script"
 
+# ActiveMQ
+if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.service.activemq.cfg" ]; then
+   /opt/karaf/bin/client -u karaf -h localhost -a 8101 "feature:install fcrepo-service-activemq"
+fi
+
 # Solr indexing
 if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.indexing.solr.cfg" ]; then
    /opt/karaf/bin/client -u karaf -h localhost -a 8101 "feature:install fcrepo-indexing-solr"
 fi
-sed -i 's|solr.baseUrl=localhost:8983/solr/collection1|solr.baseUrl=localhost:8080/solr/collection1|' /opt/karaf/etc/org.fcrepo.camel.indexing.solr.cfg
-sed -i 's|fcrepo.authUsername=$|fcrepo.authUsername=fedoraAdmin|' /opt/karaf/etc/org.fcrepo.camel.indexing.solr.cfg
-sed -i 's|fcrepo.authPassword=$|fcrepo.authPassword=secret3|' /opt/karaf/etc/org.fcrepo.camel.indexing.solr.cfg
+sed -i 's|solr.baseUrl=http://localhost:8983/solr/collection1|solr.baseUrl=http://localhost:8080/solr/collection1|' /opt/karaf/etc/org.fcrepo.camel.indexing.solr.cfg
 
 # Triplestore indexing
 if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.indexing.triplestore.cfg" ]; then
    /opt/karaf/bin/client -u karaf -h localhost -a 8101 "feature:install fcrepo-indexing-triplestore"
 fi
-sed -i 's|fcrepo.authUsername=$|fcrepo.authUsername=fedoraAdmin|' /opt/karaf/etc/org.fcrepo.camel.indexing.triplestore.cfg
-sed -i 's|fcrepo.authPassword=$|fcrepo.authPassword=secret3|' /opt/karaf/etc/org.fcrepo.camel.indexing.triplestore.cfg
 
 # Audit service
 if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.audit.cfg" ]; then
@@ -40,21 +41,18 @@ if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.fixity.cfg" ]; then
    /opt/karaf/bin/client -u karaf -h localhost -a 8101 "feature:install fcrepo-fixity"
    sleep 10
 fi
-sed -i 's|fcrepo.authUsername=$|fcrepo.authUsername=fedoraAdmin|' /opt/karaf/etc/org.fcrepo.camel.fixity.cfg
-sed -i 's|fcrepo.authPassword=$|fcrepo.authPassword=secret3|' /opt/karaf/etc/org.fcrepo.camel.fixity.cfg
 
 # Serialization service
 if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.serialization.cfg" ]; then
    /opt/karaf/bin/client -u karaf -h localhost -a 8101 "feature:install fcrepo-serialization"
 fi
-sed -i 's|fcrepo.authUsername=$|fcrepo.authUsername=fedoraAdmin|' /opt/karaf/etc/org.fcrepo.camel.serialization.cfg
-sed -i 's|fcrepo.authPassword=$|fcrepo.authPassword=secret3|' /opt/karaf/etc/org.fcrepo.camel.serialization.cfg
 
 # Reindexing service
 if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.reindexing.cfg" ]; then
    /opt/karaf/bin/client -u karaf -h localhost -a 8101 "feature:install fcrepo-reindexing"
 fi
-sed -i 's|fcrepo.authUsername=$|fcrepo.authUsername=fedoraAdmin|' /opt/karaf/etc/org.fcrepo.camel.reindexing.cfg
-sed -i 's|fcrepo.authPassword=$|fcrepo.authPassword=secret3|' /opt/karaf/etc/org.fcrepo.camel.reindexing.cfg
 sed -i 's|rest.host=localhost$|rest.host=0.0.0.0|' /opt/karaf/etc/org.fcrepo.camel.reindexing.cfg
+
+sed -i 's|fcrepo.authUsername=$|fcrepo.authUsername=fedoraAdmin|' /opt/karaf/etc/org.fcrepo.camel.service.cfg
+sed -i 's|fcrepo.authPassword=$|fcrepo.authPassword=secret3|' /opt/karaf/etc/org.fcrepo.camel.service.cfg
 


### PR DESCRIPTION
This PR enables the karaf features to install, but there still appears to be an AuthZ issue with fcrepo-serialization and fcrepo-audit.
