### PR TITLE
Updates for 4.7.4 RC

### DIFF
--- a/install_scripts/config
+++ b/install_scripts/config
@@ -12,11 +12,11 @@ if [ ! -d $DOWNLOAD_DIR ]; then
   mkdir $DOWNLOAD_DIR
 fi
 
-FEDORA_VERSION=4.7.3
-FEDORA_TAG=4.7.3
+FEDORA_VERSION=4.7.4-RC-1
+FEDORA_TAG=4.7.4-RC-1
 # true to enable auth, false to disable it
 FEDORA_AUTH=true
-FEDORA_AUDIT=true
+FEDORA_AUDIT=false
 FEDORA_AUDIT_LOCATION=/audit
 
 # Configure a JDBC backend, switching this will require destroying and re-provisioning vagrant

--- a/install_scripts/fedora4.sh
+++ b/install_scripts/fedora4.sh
@@ -10,14 +10,8 @@ if [ -f "$SHARED_DIR/install_scripts/config" ]; then
   . $SHARED_DIR/install_scripts/config
 fi
 
-if [ "${FEDORA_AUTH}" = "true" ] && [ "${FEDORA_AUDIT}" = "true" ]; then
-  WEBAPP="fcrepo-webapp-plus-webac-audit-${FEDORA_VERSION}.war"
-  RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
-elif [ "${FEDORA_AUTH}" = "true" ]; then
+if [ "${FEDORA_AUTH}" = "true" ]; then
   WEBAPP="fcrepo-webapp-plus-webac-${FEDORA_VERSION}.war"
-  RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
-elif [ "${FEDORA_AUDIT}" = "true" ]; then
-  WEBAPP="fcrepo-webapp-plus-audit-${FEDORA_VERSION}.war"
   RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
 else 
   WEBAPP="fcrepo-webapp-plus-${FEDORA_VERSION}.war"
@@ -39,6 +33,7 @@ fi
 cp "$DOWNLOAD_DIR/$WEBAPP" /var/lib/tomcat7/webapps/fcrepo.war
 chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/fcrepo.war
 
+# This section should be updated with: https://jira.duraspace.org/browse/FCREPO-2531
 AUDIT_LOCATION_ARG="fcrepo.audit.container"
 if [ "${FEDORA_AUDIT}" == "true" ] && ! grep -q "${AUDIT_LOCATION_ARG}" /etc/default/tomcat7 ; then
   echo $'\n' >>  /etc/default/tomcat7;


### PR DESCRIPTION
- Update version of Fedora from 4.7.3 to 4.7.4-RC-1
- Remove Fedora audit war

Note: There is a follow-on ticket to simplify re-enabling audit next:
https://jira.duraspace.org/browse/FCREPO-2531

p.s. Please do not squash these two commits.