### PR TITLE
Reduce maxRedeliveries from 10 to 1 and Solr commit time from 10s to 1

### DIFF
--- a/install_scripts/fedora_camel_toolbox.sh
+++ b/install_scripts/fedora_camel_toolbox.sh
@@ -32,11 +32,14 @@ if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.indexing.solr.cfg" ]; then
    /opt/karaf/bin/client -u karaf -h localhost -a 8101 "feature:install fcrepo-indexing-solr"
 fi
 sed -i 's|solr.baseUrl=http://localhost:8983/solr/collection1|solr.baseUrl=http://localhost:8080/solr/collection1|' /opt/karaf/etc/org.fcrepo.camel.indexing.solr.cfg
+sed -i 's|error.maxRedeliveries=10|error.maxRedeliveries=1|' /opt/karaf/etc/org.fcrepo.camel.indexing.solr.cfg
+sed -i 's|solr.commitWithin=10000|solr.commitWithin=1000|' /opt/karaf/etc/org.fcrepo.camel.indexing.solr.cfg
 
 # Triplestore indexing
 if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.indexing.triplestore.cfg" ]; then
    /opt/karaf/bin/client -u karaf -h localhost -a 8101 "feature:install fcrepo-indexing-triplestore"
 fi
+sed -i 's|error.maxRedeliveries=10|error.maxRedeliveries=1|' /opt/karaf/etc/org.fcrepo.camel.indexing.triplestore.cfg
 
 # Audit service
 if [ ! -f "/opt/karaf/etc/org.fcrepo.camel.audit.cfg" ]; then


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2669

# What does this Pull Request do?
Alters the fcrepo-camel-toolbox to change 2 settings. One for retries and one for commit time.

# How should this be tested?

Bring up vagrant with this PR.
Edit `/opt/apache-karaf-4.0.5/etc/org.fcrepo.camel.indexing.solr.cfg`
See that `error.maxRedeliveries=1` not `error.maxRedeliveries=10`
See that `solr.commitWithin=1000` not `solr.commitWithin=10000`
Edit `/opt/apache-karaf-4.0.5/etc/org.fcrepo.camel.indexing.triplestore.cfg`
See that `error.maxRedeliveries=1` not `error.maxRedeliveries=10`

# Additional Notes:
This is really just a cosmetic change, it helps when you might run automated testing against the repository as it reduces the number of times it will try to index any objects that are inserted and then deleted from the repository. It also speeds up how quickly Solr will display newly indexed objects.

# Interested parties
@dbernstein @bseeger @awoods 
