### PR TITLE
Add Hawtio feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ You can shell into the machine with `vagrant ssh` or `ssh -p 2222 vagrant@localh
     * Persistent storage `/etc/fuseki/databases/test\_data`
   * [Fcrepo-camel-toolbox 4.x](https://github.com/fcrepo4-exts/fcrepo-camel-toolbox)
     * Installed in karaf
+  * [Hawtio 2.5.0](https://hawt.io/)
+    * Available at [http://localhost:8181/hawtio](http://localhost:8181/hawtio)
+    * Access via username = "karaf", password = "karaf"
+    * Installed in karaf
 
 ### Fedora Configuration
 
@@ -93,6 +97,10 @@ The Solr indexer has been configured to communicate with Solr running on port 80
 The triplestore indexer has been configured to NOT include any `Prefer` headers. The production default is to limit the triples to be indexed by omitting `ldp:contains` triples.
 
 The reindexing service has been configured to bind to the host, `0.0.0.0`, instead of the default `localhost`. This allows the reindexing service to be accessible from outside of the Vagrant VM, i.e. from the host machine. See [camel-jetty documentation](http://camel.apache.org/jetty.html), search for: "Usage of localhost".
+
+### Hawtio
+
+Hawtio is a pluggable management console for Java stuff which supports any kind of JVM, any kind of container (Tomcat, Jetty, Wildfly, Karaf, etc), and any kind of Java technology and middleware. It has a Camel plugin, that allows you to gain insight into your running Camel applications.
 
 ## Support
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	config.vm.box = "fcrepo/fcrepo4-base"
 
 	config.vm.network :forwarded_port, guest: 8080, host: 8080 # Tomcat
+	config.vm.network :forwarded_port, guest: 8181, host: 8181 # Hawtio
 	config.vm.network :forwarded_port, guest: 9080, host: 9080 # Fixity and Reindexing
 
   config.vm.provider "virtualbox" do |v|
@@ -22,5 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", path: "./install_scripts/fedora4.sh", args: shared_dir
   config.vm.provision "shell", path: "./install_scripts/backup_restore.sh", args: shared_dir
   config.vm.provision "shell", path: "./install_scripts/fedora_camel_toolbox.sh", args: shared_dir
+  config.vm.provision "shell", path: "./install_scripts/hawtio.sh", args: shared_dir
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,9 +20,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   shared_dir = "/vagrant"
 
-  config.vm.provision "shell", path: "./install_scripts/fedora4.sh", args: shared_dir
-  config.vm.provision "shell", path: "./install_scripts/backup_restore.sh", args: shared_dir
-  config.vm.provision "shell", path: "./install_scripts/fedora_camel_toolbox.sh", args: shared_dir
-  config.vm.provision "shell", path: "./install_scripts/hawtio.sh", args: shared_dir
+  config.vm.provision "fedora4", type: "shell", path: "./install_scripts/fedora4.sh", args: shared_dir
+  config.vm.provision "backup_restore", type: "shell", path: "./install_scripts/backup_restore.sh", args: shared_dir
+  config.vm.provision "fedora_camel_toolbox", type: "shell", path: "./install_scripts/fedora_camel_toolbox.sh", args: shared_dir
+  config.vm.provision "hawtio", type: "shell", path: "./install_scripts/hawtio.sh", args: shared_dir
 
 end

--- a/install_scripts/fedora_camel_toolbox.sh
+++ b/install_scripts/fedora_camel_toolbox.sh
@@ -67,4 +67,3 @@ sed -i 's|rest.host=localhost$|rest.host=0.0.0.0|' /opt/karaf/etc/org.fcrepo.cam
 sed -i 's|fcrepo.authUsername=$|fcrepo.authUsername=fedoraAdmin|' /opt/karaf/etc/org.fcrepo.camel.service.cfg
 sed -i 's|fcrepo.authPassword=$|fcrepo.authPassword=secret3|' /opt/karaf/etc/org.fcrepo.camel.service.cfg
 
-/etc/init.d/karaf-service restart

--- a/install_scripts/hawtio.sh
+++ b/install_scripts/hawtio.sh
@@ -1,0 +1,9 @@
+######################
+# Fedora Camel Toolbox
+######################
+
+echo "Installing Hawt.io"
+
+/opt/karaf/bin/client -u karaf -h localhost -a 8101 "feature:repo-add hawtio 2.5.0"
+/opt/karaf/bin/client -u karaf -h localhost -a 8101 "feature:install hawtio"
+


### PR DESCRIPTION
**This PR adds the Hawtio application as a Karaf feature and exposes the Hawtio GUI via port mapping**
* * *

**JIRA Ticket**: No ticket

# What does this Pull Request do?
This PR adds the installation of the Hawtio 2.5.0 Karaf feature. The Hawtio web interface is exposed on http://localhost:8181/hawtio. Login is possible via the default Karaf credentials (karaf:karaf).

Hawtio is a useful web console for monitoring and controlling JMX resources like Camel contexts and routes: https://hawt.io/

# What's new?
* Removed unnecessary Karaf restart from fedora_camel_toolbox install script
* Names individual shell provisioners so that they can be executed individually
* Added Hawtio Karaf feature installation

# How should this be tested?
* Rebuild and start the Vagrant VM
* Hawtio GUI should be available under http://localhost:8181/hawtio

# Additional Notes:

# Interested parties
@fcrepo4/committers
