### PR TITLE
Pull from new repo starting with 5.0.0

### DIFF
--- a/install_scripts/config
+++ b/install_scripts/config
@@ -12,8 +12,8 @@ if [ ! -d $DOWNLOAD_DIR ]; then
   mkdir $DOWNLOAD_DIR
 fi
 
-FEDORA_VERSION=4.7.5
-FEDORA_TAG=4.7.5
+FEDORA_VERSION=5.0.2
+FEDORA_TAG=5.0.2
 # true to enable auth, false to disable it
 FEDORA_AUTH=true
 FEDORA_AUDIT=false

--- a/install_scripts/fedora4.sh
+++ b/install_scripts/fedora4.sh
@@ -10,18 +10,26 @@ if [ -f "$SHARED_DIR/install_scripts/config" ]; then
   . $SHARED_DIR/install_scripts/config
 fi
 
-if [ "${FEDORA_AUTH}" = "true" ] && [ "${FEDORA_AUDIT}" = "true" ]; then
-  WEBAPP="fcrepo-webapp-plus-webac-audit-${FEDORA_VERSION}.war"
-  RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
-elif [ "${FEDORA_AUTH}" = "true" ]; then
-  WEBAPP="fcrepo-webapp-plus-webac-${FEDORA_VERSION}.war"
-  RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
-elif [ "${FEDORA_AUDIT}" = "true" ]; then
-  WEBAPP="fcrepo-webapp-plus-audit-${FEDORA_VERSION}.war"
-  RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
-else 
-  WEBAPP="fcrepo-webapp-plus-${FEDORA_VERSION}.war"
-  RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
+# Converts semantic version strings to numbers
+function version { echo "$@" | gawk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
+
+if [ "$(version ${FEDORA_VERSION})" -lt "$(version 5.0.0)" ]; then
+  if [ -n "${FEDORA_AUTH}" -a -n "${FEDORA_AUDIT}" ] && [ "${FEDORA_AUTH}" = "true" ] && [ "${FEDORA_AUDIT}" = "true" ]; then
+    WEBAPP="fcrepo-webapp-plus-webac-audit-${FEDORA_VERSION}.war"
+    RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
+  elif [ -n "${FEDORA_AUTH}" ] && [ "${FEDORA_AUTH}" = "true" ]; then
+    WEBAPP="fcrepo-webapp-plus-webac-${FEDORA_VERSION}.war"
+    RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
+  elif [ -n "{$FEDORA_AUDIT}" ] && [ "${FEDORA_AUDIT}" = "true" ]; then
+    WEBAPP="fcrepo-webapp-plus-audit-${FEDORA_VERSION}.war"
+    RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
+  else 
+    WEBAPP="fcrepo-webapp-plus-${FEDORA_VERSION}.war"
+    RELEASES="https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_TAG}"
+  fi
+else
+  WEBAPP="fcrepo-webapp-${FEDORA_VERSION}.war"
+  RELEASES="https://github.com/fcrepo4/fcrepo4/releases/download/fcrepo-${FEDORA_TAG}"
 fi
 
 cd $HOME_DIR
@@ -31,7 +39,7 @@ chown tomcat7:tomcat7 /var/lib/tomcat7/fcrepo4-data
 chmod g-w /var/lib/tomcat7/fcrepo4-data
 
 if [ ! -f "$DOWNLOAD_DIR/$WEBAPP" ]; then
-  echo -n "Downloading Fedora 4... $RELEASES/$WEBAPP"
+  echo -n "Downloading Fedora... $RELEASES/$WEBAPP"
   curl -L -s -o "$DOWNLOAD_DIR/$WEBAPP" "$RELEASES/$WEBAPP"
   echo " done"
 fi


### PR DESCRIPTION
**JIRA Ticket**: n/a

# What does this Pull Request do?
Starting with version 5.0.0 we no longer download from the fcrepo-webapp-plus repository. This does a comparison of the requested version number and sets the download URI accordingly.

# How should this be tested?

Should be able to use this to build a vagrant with both 4.7.5 and 5.0.0 Fedoras

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
