### PR TITLE
Header provider - rebased

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,6 @@ The following three Fedora user accounts are available:
  * user account `adminuser`, with password `password2`
  * admin account `fedoraAdmin` with the password `secret3`
 
-### Fedora Configuration
-WebAC authorization is enabled on this Fedora installation.  
-The following three Fedora user accounts are available:
- * user account `testuser`, with password `password1`
- * user account `adminuser`, with password `password2`
- * admin account `fedoraAdmin` with the password `secret3`
-
-
 ### Using the backup and restore scripts
 The scripts at the ~/backup_restore directory can be used to test backing up and restoring the Fedora repository for consistency.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ The following three Fedora user accounts are available:
  * user account `adminuser`, with password `password2`
  * admin account `fedoraAdmin` with the password `secret3`
 
+### Fedora Configuration
+WebAC authorization is enabled on this Fedora installation.  
+The following three Fedora user accounts are available:
+ * user account `testuser`, with password `password1`
+ * user account `adminuser`, with password `password2`
+ * admin account `fedoraAdmin` with the password `secret3`
+
+
 ### Using the backup and restore scripts
 The scripts at the ~/backup_restore directory can be used to test backing up and restoring the Fedora repository for consistency.
 

--- a/README.md
+++ b/README.md
@@ -42,14 +42,12 @@ You can shell into the machine with `vagrant ssh` or `ssh -p 2222 vagrant@localh
     * Access via username = "karaf", password = "karaf"
     * Installed in karaf
 
-
 ### Fedora Configuration
 WebAC authorization is enabled on this Fedora installation.  
 The following three Fedora user accounts are available:
  * user account `testuser`, with password `password1`
  * user account `adminuser`, with password `password2`
  * admin account `fedoraAdmin` with the password `secret3`
-
 
 ### Using the backup and restore scripts
 The scripts at the ~/backup_restore directory can be used to test backing up and restoring the Fedora repository for consistency.

--- a/install_scripts/fcrepo-config.xml
+++ b/install_scripts/fcrepo-config.xml
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:task="http://www.springframework.org/schema/task"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+    http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
+    http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <!-- Master context for fcrepo4. -->
+
+    <!-- Context that supports the actual ModeShape JCR itself -->
+    <context:property-placeholder/>
+    <context:annotation-config/>
+    <context:component-scan base-package="org.fcrepo"/>
+
+
+        <!-- **********************************
+                        MODESHAPE configuration
+                 ********************************** -->
+        
+    <!-- Authentication Not Enabled -->
+    <!--
+    <bean name="modeshapeRepofactory"
+        class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
+        p:repositoryConfiguration="${fcrepo.modeshape.configuration}" />
+    -->
+    <!-- To use Authentication:
+      1. Comment out the above bean definition.
+      2. Uncomment this bean definition.
+      3. Uncomment one of the provider definitions (WebAC)
+      4. Uncomment the "authenticationProvider" bean definition below.
+    -->
+
+    <bean name="modeshapeRepofactory"
+        class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
+        p:repositoryConfiguration="${fcrepo.modeshape.configuration}"
+        depends-on="authenticationProvider"/>
+  
+    <bean name="authenticationProvider" class="org.fcrepo.auth.common.ShiroAuthenticationProvider"/>
+        
+
+
+    <!-- **************************
+              Authentication
+         ************************** -->
+
+    <!-- Optional PrincipalProvider filter that will inspect the request header, "some-header", for user role values -->
+    <bean name="headerProvider" class="org.fcrepo.auth.common.HttpHeaderPrincipalProvider">
+        <property name="headerName" value="some-header"/>
+        <property name="separator" value=","/>
+    </bean>
+
+    <!-- Optional PrincipalProvider filter that will use container configured roles as principals -->
+    <!--
+    <bean name="containerRolesProvider" class="org.fcrepo.auth.common.ContainerRolesPrincipalProvider">
+      <property name="roleNames">
+        <util:set set-class="java.util.HashSet">
+          <value>tomcat-role-1</value>
+          <value>tomcat-role-2</value>
+        </util:set>
+      </property>
+    </bean>
+    -->
+
+    <!-- delegatedPrincipleProvider filter allows a single user to be passed in the header "On-Behalf-Of",
+           this is to be used as the actor making the request when authenticating.
+           NOTE: On users with the role fedoraAdmin can delegate to another user.
+           NOTE: Only supported in WebAC authentication -->
+    <bean name="delegatedPrincipalProvider" class="org.fcrepo.auth.common.DelegateHeaderPrincipalProvider"/>
+
+    <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
+
+    <!-- Shiro Auth Confiuration -->
+    <!-- Define the Shiro Realm implementation you want to use to connect to your back-end -->
+    <!-- WebAC Authorization Realm -->
+    <bean id="webACAuthorizingRealm" class="org.fcrepo.auth.webac.WebACAuthorizingRealm" />
+
+    <!-- Servlet Container Authentication Realm -->
+    <bean id="servletContainerAuthenticatingRealm" class="org.fcrepo.auth.common.ServletContainerAuthenticatingRealm" />
+
+    <!-- Security Manager  -->
+    <bean id="securityManager" class="org.apache.shiro.web.mgt.DefaultWebSecurityManager">
+      <property name="realms">
+        <util:set set-class="java.util.HashSet">
+          <ref bean="webACAuthorizingRealm"/>
+          <ref bean="servletContainerAuthenticatingRealm"/>
+        </util:set>
+      </property>
+      <!-- By default the servlet container sessions will be used.  Uncomment this line
+          to use shiro's native sessions (see the JavaDoc for more): -->
+      <!-- <property name="sessionMode" value="native"/> -->
+    </bean>
+
+    <!-- Post processor that automatically invokes init() and destroy() methods -->
+    <bean id="lifecycleBeanPostProcessor" class="org.apache.shiro.spring.LifecycleBeanPostProcessor"/>
+
+    <!-- Authentication Filter -->
+    <bean id="servletContainerAuthFilter" class="org.fcrepo.auth.common.ServletContainerAuthFilter"/>
+
+    <!-- Authorization Filter -->
+    <bean id="webACFilter" class="org.fcrepo.auth.webac.WebACFilter"/>
+
+    <bean id="shiroFilter" class="org.apache.shiro.spring.web.ShiroFilterFactoryBean">
+      <property name="securityManager" ref="securityManager"/>
+      <property name="filterChainDefinitions">
+        <value>
+          <!-- The Auth filter should come first, followed by 0 or more of the principal provider filters, -->
+          <!-- and finally the webACFilter -->
+          /** = servletContainerAuthFilter,delegatedPrincipalProvider,headerProvider,webACFilter
+        </value>
+      </property>
+    </bean>
+
+    <!-- **************************
+            END Authentication
+         ************************** -->
+
+
+    <!-- **************************
+                 AUDIT
+         publish audit events to JMS
+         ************************** -->
+    <!--
+    <bean class="org.fcrepo.audit.InternalAuditor"/>
+    -->
+
+    <!-- **************************
+              PID Minter
+         ************************** -->
+    <!-- Mint hierarchical identifiers with args to control length and count
+          of the pairtree. A length or count of ZERO will return a 
+          non-hierarchical identifier.
+    <bean class="org.fcrepo.kernel.api.services.functions.ConfigurableHierarchicalSupplier"
+        c:desiredLength="${fcrepo.uuid.path.length:2}"
+        c:desiredCount="${fcrepo.uuid.path.count:4}"/>
+    -->
+
+    <!-- Mints Pids with no additional hierarchy.
+          Choose this if you use the AppleTreeConverter
+          in the translation chain below. -->
+    <!--
+    <bean class="org.fcrepo.mint.UUIDPidMinter" />
+    -->
+
+    <!-- Mints PIDs using external REST service
+    <bean class="org.fcrepo.mint.HttpPidMinter"
+        c:url="http://localhost/my/minter" c:method="POST"
+        c:username="${fcrepo.minter.username:minterUser}"
+        c:password="${fcrepo.minter.password:minterPass}"
+        c:regex="" c:xpath="/response/ids/value"/>
+    -->
+
+    
+    <!-- Identifier translation chain -->
+    <util:list id="translationChain" value-type="org.fcrepo.kernel.api.identifiers.InternalIdentifierConverter">
+      <!-- Use AppleTreeConverter to hide Fedora's Pairtree hierarchy from public view
+          https://gitlab.amherst.edu/acdc/acrepo-apple-trees.
+          NOTE: It is recommended to use the UUIDPidMinter above with this converter.
+      -->
+      <!--
+        <bean class="edu.amherst.acdc.orchard.AppleTreeConverter"/>
+      -->
+        <bean class="org.fcrepo.kernel.modeshape.identifiers.HashConverter"/>
+        <bean class="org.fcrepo.kernel.modeshape.identifiers.NamespaceConverter"/>
+    </util:list>
+
+
+    <!-- *************************************
+               JMS/Eventing Configuration
+         ************************************* -->
+    
+    <!-- publishes events from the internal bus to a JMS Topic or Queue.
+         "constructor-arg" for both is topic/queue name. -->
+    
+    <!-- JMS Topic -->
+    <!-- IMPORTANT: While the JMS Topic is adequate for demonstrating Fedora's JMS message system,
+                    for production use it is recommended to either use the JMS Queue instead,
+                    or to disable JMS messaging entirely if you are not using any services that
+                    require it (e.g., indexers, fixity checking, auditing, etc.) -->
+    <bean class="org.fcrepo.jms.JMSTopicPublisher">
+      <constructor-arg value="fedora"/>
+    </bean>
+    
+    <!-- JMS Queue -->
+    <!-- The JMS Queue is the RECOMMENDED messaging configuration for production deployments.
+         Unlike the topic, the queue will retain messages until they are consumed. To use the
+         queue, comment out the topic bean above and uncomment the queue bean below. -->
+    <!--
+    <bean class="org.fcrepo.jms.JMSQueuePublisher">
+      <constructor-arg value="fedora"/>
+    </bean>
+    -->
+    
+    <!-- ActiveMQ connection -->  
+    <bean id="connectionFactory"
+        class="org.apache.activemq.ActiveMQConnectionFactory" depends-on="jmsBroker"
+        p:brokerURL="vm://${fcrepo.jms.host:localhost}:${fcrepo.dynamic.jms.port:61616}?create=false"/>
+
+    <!-- JMS Broker configuration -->
+    <bean name="jmsBroker" class="org.apache.activemq.xbean.BrokerFactoryBean"
+      p:config="${fcrepo.activemq.configuration:classpath:/config/activemq.xml}" p:start="true"/>
+
+
+    <!-- translates events into JMS header-only format-->
+    <bean class="org.fcrepo.jms.DefaultMessageFactory"/>
+
+    <!-- listener that moves JCR Events to the Fedora internal event bus -->
+    <bean class="org.fcrepo.kernel.modeshape.observer.SimpleObserver"/>
+
+    <!-- used by bean above to filter which events get put on the bus -->
+    <bean name="fedoraEventFilter" class="org.fcrepo.kernel.modeshape.observer.DefaultFilter"/>
+
+    <!-- used by observer bean to map JCR events into Fedora events -->
+    <bean name="fedoraEventMapper" class="org.fcrepo.kernel.modeshape.observer.eventmappings.AllNodeEventsOneEvent"/>
+
+    <!-- Fedora's lightweight internal event bus. Currently memory-resident.-->
+    <bean name="fedoraInternalEventBus" class="com.google.common.eventbus.EventBus"/>
+
+    <!-- Configuration of namespace prefixes -->
+    <bean name="rdfNamespaceRegistry" class="org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry"
+        init-method="init" destroy-method="shutdown">
+      <property name="configPath" value="${fcrepo.namespace.registry:classpath:/namespaces.yml}" />
+      <property name="monitorForChanges" value="true" />
+    </bean>
+
+    <!-- External content configuration -->
+    <bean name="externalContentPathValidator" class="org.fcrepo.http.api.ExternalContentPathValidator"
+        init-method="init" destroy-method="shutdown">
+        <property name="configPath" value="${fcrepo.external.content.allowed:#{null}}" />
+        <property name="monitorForChanges" value="true" />
+    </bean>
+    
+    <bean name="externalContentHandlerFactory" class="org.fcrepo.http.api.ExternalContentHandlerFactory">
+        <property name="validator" ref="externalContentPathValidator" />
+    </bean>
+
+    <!-- ***********************************
+            Internal system configuration
+         *********************************** -->
+    <task:scheduler id="taskScheduler" />
+    <task:executor id="taskExecutor" pool-size="1" />
+    <task:annotation-driven executor="taskExecutor" scheduler="taskScheduler" />
+
+
+    <!-- Start the Modeshape JCR -->
+    <bean class="org.modeshape.jcr.ModeShapeEngine" init-method="start"/>
+
+    <bean id="connectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager" />
+
+    <!-- Generates HTTP Sessions -->
+    <bean class="org.fcrepo.http.commons.session.SessionFactory"/>
+    
+</beans>

--- a/install_scripts/fedora.sh
+++ b/install_scripts/fedora.sh
@@ -42,6 +42,10 @@ if ! grep -q "fcrepo.modeshape.configuration" /etc/default/tomcat7 ; then
   echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.modeshape.configuration=${MODESHAPE_CONFIG}\"" >> /etc/default/tomcat7;
 fi
 
+if [ ! -f "$HOME_DIR/fcrepo-config.xml" ]; then
+  cp "$SHARED_DIR/install_scripts/fcrepo-config.xml" $HOME_DIR
+fi
+
 echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.external.content.allowed=$SHARED_DIR/install_scripts/external-content-allowed-paths.txt\"" >> /etc/default/tomcat7;
 echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.properties.management=relaxed\"" >> /etc/default/tomcat7;
 

--- a/install_scripts/fedora.sh
+++ b/install_scripts/fedora.sh
@@ -42,11 +42,15 @@ if ! grep -q "fcrepo.modeshape.configuration" /etc/default/tomcat7 ; then
   echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.modeshape.configuration=${MODESHAPE_CONFIG}\"" >> /etc/default/tomcat7;
 fi
 
+echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.external.content.allowed=$SHARED_DIR/install_scripts/external-content-allowed-paths.txt\"" >> /etc/default/tomcat7;
+echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.properties.management=relaxed\"" >> /etc/default/tomcat7;
+
 if [ ! -f "$HOME_DIR/fcrepo-config.xml" ]; then
   cp "$SHARED_DIR/install_scripts/fcrepo-config.xml" $HOME_DIR
 fi
 
-echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.external.content.allowed=$SHARED_DIR/install_scripts/external-content-allowed-paths.txt\"" >> /etc/default/tomcat7;
-echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.properties.management=relaxed\"" >> /etc/default/tomcat7;
+if ! grep -q "fcrepo.spring.configuration" /etc/default/tomcat7 ; then
+  echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.spring.configuration=file://${HOME_DIR}/fcrepo-config.xml\"" >> /etc/default/tomcat7;
+fi
 
 service tomcat7 restart

--- a/install_scripts/fedora_camel_toolbox.script
+++ b/install_scripts/fedora_camel_toolbox.script
@@ -1,6 +1,6 @@
 feature:repo-add mvn:org.apache.activemq/activemq-karaf/5.14.1/xml/features
-feature:repo-add mvn:org.apache.camel.karaf/apache-camel/2.20.0/xml/features
-feature:repo-add mvn:org.fcrepo.camel/toolbox-features/5.0.0-SNAPSHOT/xml/features
+feature:repo-add mvn:org.apache.camel.karaf/apache-camel/2.20.4/xml/features
+feature:repo-add mvn:org.fcrepo.camel/toolbox-features/5.0.0/xml/features
 feature:install fcrepo-service-activemq
 feature:install fcrepo-service-camel
 feature:install fcrepo-ldpath


### PR DESCRIPTION
**This is @whikloj's PR (https://github.com/fcrepo4-exts/fcrepo4-vagrant/pull/92 - now closed) rebased and merged on my latest PR (https://github.com/fcrepo4-exts/fcrepo4-vagrant/pull/94).**
* * *
Once https://github.com/fcrepo4-exts/fcrepo4-vagrant/pull/94 has been merged,  I will merge this one.

Text of the original PR follows: 
***
**JIRA Ticket**: n/a

# What does this Pull Request do?
Installs a customized `fcrepo-config.xml` with the headerPrincipalProvider enabled.

# How should this be tested?

Need to stand up this vagrant, then create a resource and restrict it to one of the users (ie. adminuser). 

Then try to access that resource using the other user and the header
ie.
```
curl -i -u testuser:password1 -H"some-header: adminuser" http://localhost:8080/fcrepo/rest/your_restricted_resource
```
# Additional Notes:

Example:
* Does this change require documentation to be updated? yes, some information about the header might be helpful.
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
