### PR TITLE
Ensures that external content path file is included in export.

### DIFF
--- a/install_scripts/fedora.sh
+++ b/install_scripts/fedora.sh
@@ -42,7 +42,11 @@ if ! grep -q "fcrepo.modeshape.configuration" /etc/default/tomcat7 ; then
   echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.modeshape.configuration=${MODESHAPE_CONFIG}\"" >> /etc/default/tomcat7;
 fi
 
-echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.external.content.allowed=$SHARED_DIR/install_scripts/external-content-allowed-paths.txt\"" >> /etc/default/tomcat7;
+if [ ! -f "$HOME_DIR/external-content-allowed-paths.txt" ]; then
+  cp "$SHARED_DIR/install_scripts/external-content-allowed-paths.txt" $HOME_DIR
+fi
+
+echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.external.content.allowed=${HOME_DIR}/external-content-allowed-paths.txt\"" >> /etc/default/tomcat7;
 echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.properties.management=relaxed\"" >> /etc/default/tomcat7;
 
 if [ ! -f "$HOME_DIR/fcrepo-config.xml" ]; then


### PR DESCRIPTION
Previously on a `vagrant package` command (in order to export to a .box file) the external content paths file was not being saved in the $HOME directory on installation.

This change can be tested by:

1. `vagrant up`
2. `vagrant ssh`
3.  verify that the external-content-allowed-paths.txt is present in the /home/vagrant/ directory.

# Interested parties
@fcrepo4/committers
