### PR TITLE
Fix karaf repositories

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   shared_dir = "/vagrant"
 
+  config.vm.provision "bootstrap", type: "shell", path: "./install_scripts/bootstrap.sh", args: shared_dir
   config.vm.provision "fedora", type: "shell", path: "./install_scripts/fedora.sh", args: shared_dir
   config.vm.provision "backup_restore", type: "shell", path: "./install_scripts/backup_restore.sh", args: shared_dir
   config.vm.provision "fedora_camel_toolbox", type: "shell", path: "./install_scripts/fedora_camel_toolbox.sh", args: shared_dir

--- a/install_scripts/bootstrap.sh
+++ b/install_scripts/bootstrap.sh
@@ -1,0 +1,19 @@
+######################
+# Update box
+######################
+
+echo "Updating base box configuration"
+
+SHARED_DIR=$1
+
+if [ -f "$SHARED_DIR/install_scripts/config" ]; then
+  . $SHARED_DIR/install_scripts/config
+fi
+
+cd $HOME_DIR
+
+if [ -f "/opt/karaf/etc/org.ops4j.pax.url.mvn.cfg" ]; then
+  sed -i "s/http:\/\/repo1.maven.org/https:\/\/repo1.maven.org/g" /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg
+fi
+/etc/init.d/karaf-service restart
+


### PR DESCRIPTION
**JIRA Ticket**: n/a

# What does this Pull Request do?
Fixes the default maven respository in the Karaf to use `https`

# How should this be tested?

Before this PR your `vagrant up` should fail with
```
Error executing command: No matching features for fcrepo-reindexing/0.0.0
    default: sed: can't read /opt/karaf/etc/org.fcrepo.camel.reindexing.cfg: No such file or directory
    default: sed: can't read /opt/karaf/etc/org.fcrepo.camel.service.cfg: No such file or directory
    default: sed: can't read /opt/karaf/etc/org.fcrepo.camel.service.cfg: No such file or directory
```

Now should not

# Interested parties
@fcrepo4-exts/fcrepo4-exts-owners specifically @bbpennel 
