### PR TITLE
Bump up to 5.1.1

### DIFF
--- a/install_scripts/config
+++ b/install_scripts/config
@@ -12,8 +12,8 @@ if [ ! -d $DOWNLOAD_DIR ]; then
   mkdir $DOWNLOAD_DIR
 fi
 
-FEDORA_VERSION=5.1.0
-FEDORA_TAG=5.1.0
+FEDORA_VERSION=5.1.1
+FEDORA_TAG=5.1.1
 
 # Configure a JDBC backend, switching this will require destroying and re-provisioning vagrant
 FEDORA_JDBC_STORE=file


### PR DESCRIPTION
Causes  `vagrant up` to build the latest released  Fedora (5.1.1).

Test by  `vagrant up` and check that the instance works.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
